### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.13] - 2026-03-25
+
+### 🐛 Fixed
+
+- **client**: filter ([#363](https://github.com/tegojs/tego-standard/pull/363)) (@TomyJan)
+- **desktop**: fix tego wrapper script ([#362](https://github.com/tegojs/tego-standard/pull/362)) (@bai.zixv)
+- **desktop**: fix mac server start error ([#361](https://github.com/tegojs/tego-standard/pull/361)) (@bai.zixv)
+
 ## [1.6.12] - 2026-03-23
 
 ### 🐛 Fixed
@@ -2948,7 +2956,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.12...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.13...HEAD
+[1.6.13]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.13
 [1.6.12]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.12
 [1.6.11]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.11
 [1.6.8-alpha.1]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.8-alpha.1

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,14 @@
 
 
 
+## [1.6.13] - 2026-03-25
+
+### 🐛 修复
+
+- **client**: 过滤器([#363](https://github.com/tegojs/tego-standard/pull/363)) (@TomyJan)
+- **desktop**: 修复 tego 包装脚本 ([#362](https://github.com/tegojs/tego-standard/pull/362)) (@bai.zixv)
+- **desktop**: 修复 mac 服务器启动错误 ([#361](https://github.com/tegojs/tego-standard/pull/361)) (@bai.zixv)
+
 ## [1.6.12] - 2026-03-23
 
 ### 🐛 修复
@@ -2948,7 +2956,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.12...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.13...HEAD
+[1.6.13]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.13
 [1.6.12]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.12
 [1.6.11]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.11
 [1.6.8-alpha.1]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.8-alpha.1


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added version 1.6.13 changelog entry documenting fixes for client filtering and desktop component issues across multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->