### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Added
+
+- **client**: apply connected source block data scope to target blocks ([#364](https://github.com/tegojs/tego-standard/pull/364)) [13d9294](https://github.com/tegojs/tego-standard/commit/13d9294b55577cef779b374612b2609800a86885) (@TomyJan)
+
 
 
 ## [1.6.13] - 2026-03-25

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -7,6 +7,10 @@
 
 ## [未发布]
 
+### ✨ 新增
+
+- **client**: 将连接的源块数据范围应用于目标块([#364](https://github.com/tegojs/tego-standard/pull/364)) [13d9294](https://github.com/tegojs/tego-standard/commit/13d9294b55577cef779b374612b2609800a86885) (@TomyJan)
+
 
 
 ## [1.6.13] - 2026-03-25


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelogs in multiple languages to reflect recent feature additions related to connected source block data scope management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->