### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+
+## [1.6.14] - 2026-04-01
+
 ### ✨ Added
 
-- **client**: apply connected source block data scope to target blocks ([#364](https://github.com/tegojs/tego-standard/pull/364)) [13d9294](https://github.com/tegojs/tego-standard/commit/13d9294b55577cef779b374612b2609800a86885) (@TomyJan)
+- **client**: apply connected source block data scope to target blocks ([#364](https://github.com/tegojs/tego-standard/pull/364)) (@TomyJan)
 
+### 🐛 Fixed
 
+- create  groublock ([#365](https://github.com/tegojs/tego-standard/pull/365)) (@dududuna)
 
 ## [1.6.13] - 2026-03-25
 
@@ -2960,7 +2966,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.13...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.14...HEAD
+[1.6.14]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.14
 [1.6.13]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.13
 [1.6.12]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.12
 [1.6.11]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.11

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -7,11 +7,17 @@
 
 ## [未发布]
 
+
+
+## [1.6.14] - 2026-04-01
+
 ### ✨ 新增
 
-- **client**: 将连接的源块数据范围应用于目标块([#364](https://github.com/tegojs/tego-standard/pull/364)) [13d9294](https://github.com/tegojs/tego-standard/commit/13d9294b55577cef779b374612b2609800a86885) (@TomyJan)
+- **client**: 将连接的源块数据范围应用于目标块([#364](https://github.com/tegojs/tego-standard/pull/364)) (@TomyJan)
 
+### 🐛 修复
 
+- 创建组块([#365](https://github.com/tegojs/tego-standard/pull/365)) (@dududuna)
 
 ## [1.6.13] - 2026-03-25
 
@@ -2960,7 +2966,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.13...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.14...HEAD
+[1.6.14]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.14
 [1.6.13]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.13
 [1.6.12]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.12
 [1.6.11]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.11


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Changelog updated for version 1.6.14 release (April 1, 2026) with client updates and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->