### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.15] - 2026-04-09
+
+### ✨ Added
+
+- update locale ([#367](https://github.com/tegojs/tego-standard/pull/367)) (@bai.zixv)
+
+### 🐛 Fixed
+
+- **module-cron**: always schedule next cronjob execution ([#366](https://github.com/tegojs/tego-standard/pull/366)) (@TomyJan)
+
 ## [1.6.14] - 2026-04-01
 
 ### ✨ Added
@@ -2966,7 +2976,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.14...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.15...HEAD
+[1.6.15]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.15
 [1.6.14]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.14
 [1.6.13]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.13
 [1.6.12]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.12

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,16 @@
 
 
 
+## [1.6.15] - 2026-04-09
+
+### ✨ 新增
+
+- 更新语言环境 ([#367](https://github.com/tegojs/tego-standard/pull/367)) (@bai.zixv)
+
+### 🐛 修复
+
+- **module-cron**: 始终安排下一个 cronjob 执行 ([#366](https://github.com/tegojs/tego-standard/pull/366)) (@TomyJan)
+
 ## [1.6.14] - 2026-04-01
 
 ### ✨ 新增
@@ -2966,7 +2976,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.14...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.15...HEAD
+[1.6.15]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.15
 [1.6.14]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.14
 [1.6.13]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.13
 [1.6.12]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.12


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog for version 1.6.15 with locale updates and cronjob scheduling fixes. Reference links updated for release tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->