### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **client**: correct date range operator inference and prevent next-day range display ([#371](https://github.com/tegojs/tego-standard/pull/371)) [3214bde](https://github.com/tegojs/tego-standard/commit/3214bdecdec351e04941eb22fad308d7de3d6bc3) (@TomyJan)
 - **backup&database-clean**: stabilize download streaming and clean up diagnostics ([#368](https://github.com/tegojs/tego-standard/pull/368)) [0643986](https://github.com/tegojs/tego-standard/commit/064398676db7590b7b1dc6c0813c4b3492a568da) (@TomyJan)
 
 

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,7 @@
 
 ### 🐛 修复
 
+- **client**: 正确的日期范围运算符推断并防止第二天的范围显示 ([#371](https://github.com/tegojs/tego-standard/pull/371)) [3214bde](https://github.com/tegojs/tego-standard/commit/3214bdecdec351e04941eb22fad308d7de3d6bc3) (@TomyJan)
 - **backup&database-clean**: 稳定下载流并清理诊断 ([#368](https://github.com/tegojs/tego-standard/pull/368)) [0643986](https://github.com/tegojs/tego-standard/commit/064398676db7590b7b1dc6c0813c4b3492a568da) (@TomyJan)
 
 


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to document a client-side bug fix addressing date range operator inference and incorrect next-day range display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->