### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.17] - 2026-04-28
+
+### 🐛 Fixed
+
+- workflow script instruction resume method ([#375](https://github.com/tegojs/tego-standard/pull/375)) (@bai.zixv)
+- script instruction return error ([#374](https://github.com/tegojs/tego-standard/pull/374)) (@bai.zixv)
+
 ## [1.6.16] - 2026-04-27
 
 ### ✨ Added
@@ -2988,7 +2995,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.16...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.17...HEAD
+[1.6.17]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.17
 [1.6.16]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.16
 [1.6.15]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.15
 [1.6.14]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.14

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,13 @@
 
 
 
+## [1.6.17] - 2026-04-28
+
+### 🐛 修复
+
+- 工作流程脚本指令恢复方法 ([#375](https://github.com/tegojs/tego-standard/pull/375)) (@bai.zixv)
+- 脚本指令返回错误 ([#374](https://github.com/tegojs/tego-standard/pull/374)) (@bai.zixv)
+
 ## [1.6.16] - 2026-04-27
 
 ### ✨ 新增
@@ -2988,7 +2995,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.16...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.17...HEAD
+[1.6.17]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.17
 [1.6.16]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.16
 [1.6.15]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.15
 [1.6.14]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.14


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 1.6.17 documenting fixes for workflow script behavior in both English and Chinese changelog files.
  * Updated changelog reference links to reflect the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->