### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **client**: guard association parent lookup without source ([#377](https://github.com/tegojs/tego-standard/pull/377)) [85d97e9](https://github.com/tegojs/tego-standard/commit/85d97e9db46f94621b1d93de953dc8dc525db0d8) (@TomyJan)
+
 
 
 ## [1.6.17] - 2026-04-28

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -7,6 +7,10 @@
 
 ## [未发布]
 
+### 🐛 修复
+
+- **client**: 无源保护关联父级查找 ([#377](https://github.com/tegojs/tego-standard/pull/377)) [85d97e9](https://github.com/tegojs/tego-standard/commit/85d97e9db46f94621b1d93de953dc8dc525db0d8) (@TomyJan)
+
 
 
 ## [1.6.17] - 2026-04-28


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to document a client-side fix for association parent lookup handling when no source is present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tegojs/docs/pull/225)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->