### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+
+## [1.6.18] - 2026-05-19
+
 ### 🐛 Fixed
 
-- **client**: guard association parent lookup without source ([#377](https://github.com/tegojs/tego-standard/pull/377)) [85d97e9](https://github.com/tegojs/tego-standard/commit/85d97e9db46f94621b1d93de953dc8dc525db0d8) (@TomyJan)
-
-
+- **client**: normalize custom filter variables ([#382](https://github.com/tegojs/tego-standard/pull/382)) (@TomyJan)
+- **client&form-design**: guard missing component props ([#381](https://github.com/tegojs/tego-standard/pull/381)) (@TomyJan)
+- **client**: normalize date-only picker boundaries ([#379](https://github.com/tegojs/tego-standard/pull/379)) (@TomyJan)
+- **client**: correct custom filter variable substitution ([#380](https://github.com/tegojs/tego-standard/pull/380)) (@TomyJan)
+- **client**: guard association parent lookup without source ([#377](https://github.com/tegojs/tego-standard/pull/377)) (@TomyJan)
 
 ## [1.6.17] - 2026-04-28
 
@@ -2999,7 +3005,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.17...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.18...HEAD
+[1.6.18]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.18
 [1.6.17]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.17
 [1.6.16]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.16
 [1.6.15]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.15

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -7,11 +7,17 @@
 
 ## [未发布]
 
+
+
+## [1.6.18] - 2026-05-19
+
 ### 🐛 修复
 
-- **client**: 无源保护关联父级查找 ([#377](https://github.com/tegojs/tego-standard/pull/377)) [85d97e9](https://github.com/tegojs/tego-standard/commit/85d97e9db46f94621b1d93de953dc8dc525db0d8) (@TomyJan)
-
-
+- **client**: 规范化自定义过滤器变量 ([#382](https://github.com/tegojs/tego-standard/pull/382)) (@TomyJan)
+- **client&form-design**: 保护丢失的组件道具 ([#381](https://github.com/tegojs/tego-standard/pull/381)) (@TomyJan)
+- **client**: 标准化仅日期选择器边界([#379](https://github.com/tegojs/tego-standard/pull/379)) (@TomyJan)
+- **client**: 正确的自定义过滤器变量替换 ([#380](https://github.com/tegojs/tego-standard/pull/380)) (@TomyJan)
+- **client**: 无源保护关联父级查找 ([#377](https://github.com/tegojs/tego-standard/pull/377)) (@TomyJan)
 
 ## [1.6.17] - 2026-04-28
 
@@ -2999,7 +3005,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.17...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.18...HEAD
+[1.6.18]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.18
 [1.6.17]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.17
 [1.6.16]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.16
 [1.6.15]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.15


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.