### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.19] - 2026-05-20
+
+### 🐛 Fixed
+
+- **client**: skip empty custom filter arrays ([#384](https://github.com/tegojs/tego-standard/pull/384)) (@TomyJan)
+- **client**: datepicker range filter semantics ([#383](https://github.com/tegojs/tego-standard/pull/383)) (@TomyJan)
+
 ## [1.6.18] - 2026-05-19
 
 ### 🐛 Fixed
@@ -3005,7 +3012,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.18...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.19...HEAD
+[1.6.19]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.19
 [1.6.18]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.18
 [1.6.17]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.17
 [1.6.16]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.16

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,13 @@
 
 
 
+## [1.6.19] - 2026-05-20
+
+### 🐛 修复
+
+- **client**: 跳过空的自定义过滤器数组 ([#384](https://github.com/tegojs/tego-standard/pull/384)) (@TomyJan)
+- **client**: 日期选择器范围过滤器语义 ([#383](https://github.com/tegojs/tego-standard/pull/383)) (@TomyJan)
+
 ## [1.6.18] - 2026-05-19
 
 ### 🐛 修复
@@ -3005,7 +3012,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.18...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.19...HEAD
+[1.6.19]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.19
 [1.6.18]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.18
 [1.6.17]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.17
 [1.6.16]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.16


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.