### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.21] - 2026-05-22
+
+### 🐛 Fixed
+
+- **client**: preserve gmt:true parse for naive GMT date boundary values ([#386](https://github.com/tegojs/tego-standard/pull/386)) (@TomyJan)
+
 ## [1.6.20] - 2026-05-21
 
 ### ✨ Added
@@ -3022,7 +3028,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.20...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.21...HEAD
+[1.6.21]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.21
 [1.6.20]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.20
 [1.6.19]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.19
 [1.6.18]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.18

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,12 @@
 
 
 
+## [1.6.21] - 2026-05-22
+
+### 🐛 修复
+
+- **client**: 保留 gmt:true 解析幼稚的 GMT 日期边界值 ([#386](https://github.com/tegojs/tego-standard/pull/386)) (@TomyJan)
+
 ## [1.6.20] - 2026-05-21
 
 ### ✨ 新增
@@ -3022,7 +3028,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.20...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.21...HEAD
+[1.6.21]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.21
 [1.6.20]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.20
 [1.6.19]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.19
 [1.6.18]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.18


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated changelog to document v1.6.21 release with version reference links.

* **Bug Fixes**
  * Fixed client-side handling of GMT date boundary values during parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tegojs/docs/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->