### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Added
+
+- **workflow**: exit branch node ([#376](https://github.com/tegojs/tego-standard/pull/376)) [c53c0f2](https://github.com/tegojs/tego-standard/commit/c53c0f2f9fae19421f849da05c65cbfc86de4bde) (@TomyJan)
+
+### 🐛 Fixed
+
+- formula fields support associated field values ([#387](https://github.com/tegojs/tego-standard/pull/387)) [c7f905e](https://github.com/tegojs/tego-standard/commit/c7f905e5e0ced6529c53b995966871c6f317d37b) (@dududuna)
+
 
 
 ## [1.6.21] - 2026-05-22

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -7,6 +7,14 @@
 
 ## [未发布]
 
+### ✨ 新增
+
+- **workflow**: 退出分支节点 ([#376](https://github.com/tegojs/tego-standard/pull/376)) [c53c0f2](https://github.com/tegojs/tego-standard/commit/c53c0f2f9fae19421f849da05c65cbfc86de4bde) (@TomyJan)
+
+### 🐛 修复
+
+- 公式字段支持关联字段值 ([#387](https://github.com/tegojs/tego-standard/pull/387)) [c7f905e](https://github.com/tegojs/tego-standard/commit/c7f905e5e0ced6529c53b995966871c6f317d37b) (@dududuna)
+
 
 
 ## [1.6.21] - 2026-05-22


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新日志

* **New Features**
  * 工作流新增"退出分支节点"功能

* **Bug Fixes**
  * 公式字段现已支持关联字段值

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tegojs/docs/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->