### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **client**: restore grid schema drag context ([#396](https://github.com/tegojs/tego-standard/pull/396)) [2603533](https://github.com/tegojs/tego-standard/commit/26035333c96c6d38225fbb3fbe894530a4371e36) (@TomyJan)
+- **auth**: handle expired token response status ([#395](https://github.com/tegojs/tego-standard/pull/395)) [7a430b9](https://github.com/tegojs/tego-standard/commit/7a430b9fc8d4ce75d7f719b2358404acbc8033fd) (@TomyJan)
+
 
 
 ## [1.6.22] - 2026-06-16

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -7,6 +7,11 @@
 
 ## [未发布]
 
+### 🐛 修复
+
+- **client**: 恢复网格模式拖动上下文 ([#396](https://github.com/tegojs/tego-standard/pull/396)) [2603533](https://github.com/tegojs/tego-standard/commit/26035333c96c6d38225fbb3fbe894530a4371e36) (@TomyJan)
+- **auth**: 处理过期的令牌响应状态 ([#395](https://github.com/tegojs/tego-standard/pull/395)) [7a430b9](https://github.com/tegojs/tego-standard/commit/7a430b9fc8d4ce75d7f719b2358404acbc8033fd) (@TomyJan)
+
 
 
 ## [1.6.22] - 2026-06-16


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 在中英文更新日志的“未发布 / Unreleased”部分新增了“🐛 修复”条目。
  * 补充了两项修复记录：网格模式拖拽上下文恢复，以及过期令牌响应状态处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->