### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Added
+
+- approval quick add ([#403](https://github.com/tegojs/tego-standard/pull/403)) [b5154d0](https://github.com/tegojs/tego-standard/commit/b5154d064e929e228b5345d1a8259e0b6f6a483a) (@dududuna)
+
 
 
 ## [1.6.24] - 2026-07-09

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -7,6 +7,10 @@
 
 ## [未发布]
 
+### ✨ 新增
+
+- 审批快速添加 ([#403](https://github.com/tegojs/tego-standard/pull/403)) [b5154d0](https://github.com/tegojs/tego-standard/commit/b5154d064e929e228b5345d1a8259e0b6f6a483a) (@dududuna)
+
 
 
 ## [1.6.24] - 2026-07-09


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 在中英文变更日志的“未发布”部分新增“审批快速添加”功能记录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->