### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.26] - 2026-08-11
+
+### ✨ Added
+
+- **tenant**: platform tenant isolation ([#370](https://github.com/tegojs/tego-standard/pull/370)) (@TomyJan)
+
 ## [1.6.25] - 2026-08-10
 
 ### ✨ Added
@@ -3074,7 +3080,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.25...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.26...HEAD
+[1.6.26]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.26
 [1.6.25]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.25
 [1.6.24]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.24
 [1.6.23]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.23

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,12 @@
 
 
 
+## [1.6.26] - 2026-08-11
+
+### ✨ 新增
+
+- **tenant**: 平台租户隔离([#370](https://github.com/tegojs/tego-standard/pull/370)) (@TomyJan)
+
 ## [1.6.25] - 2026-08-10
 
 ### ✨ 新增
@@ -3074,7 +3080,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.25...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.26...HEAD
+[1.6.26]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.26
 [1.6.25]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.25
 [1.6.24]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.24
 [1.6.23]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.23


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增 1.6.26 版本更新日志，记录租户隔离功能。
  * 更新中英文版本比较链接及 1.6.26 发布链接。
  * 中文日志补充发布日期和相关变更记录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->