### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.27] - 2026-08-11
+
+### 🐛 Fixed
+
+- **workflow-approval**: ignore stale association appends (@TomyJan)
+
 ## [1.6.26] - 2026-08-11
 
 ### ✨ Added
@@ -3080,7 +3086,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.26...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.27...HEAD
+[1.6.27]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.27
 [1.6.26]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.26
 [1.6.25]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.25
 [1.6.24]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.24

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,12 @@
 
 
 
+## [1.6.27] - 2026-08-11
+
+### 🐛 修复
+
+- **workflow-approval**: 忽略陈旧的关联附加 (@TomyJan)
+
 ## [1.6.26] - 2026-08-11
 
 ### ✨ 新增
@@ -3080,7 +3086,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.26...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.27...HEAD
+[1.6.27]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.27
 [1.6.26]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.26
 [1.6.25]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.25
 [1.6.24]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.24


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增 1.6.27 版本发布记录。
  * 记录工作流审批中忽略过期关联追加的修复。
  * 更新未发布版本的比较范围及 1.6.27 发布链接。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->