### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.28] - 2026-08-11
+
+### 🐛 Fixed
+
+- **workflow-approval**: guard invalid assignee query filters (@TomyJan)
+
 ## [1.6.27] - 2026-08-11
 
 ### 🐛 Fixed
@@ -3086,7 +3092,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.27...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.28...HEAD
+[1.6.28]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.28
 [1.6.27]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.27
 [1.6.26]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.26
 [1.6.25]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.25

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,12 @@
 
 
 
+## [1.6.28] - 2026-08-11
+
+### 🐛 修复
+
+- **workflow-approval**: 保护无效的受让人查询过滤器 (@TomyJan)
+
 ## [1.6.27] - 2026-08-11
 
 ### 🐛 修复
@@ -3086,7 +3092,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.27...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.28...HEAD
+[1.6.28]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.28
 [1.6.27]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.27
 [1.6.26]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.26
 [1.6.25]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.25


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复工作流审批中无效受让人查询过滤器未生效的问题。

* **Documentation**
  * 更新中英文变更日志，新增 1.6.28 版本记录及发布链接。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->