### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.29] - 2026-08-11
+
+### 🐛 Fixed
+
+- **workflow**: normalize empty script sources (@TomyJan)
+- **workflow**: handle legacy script nodes without sources (@TomyJan)
+- **workflow-approval**: guard stale summary associations (@TomyJan)
+
 ## [1.6.28] - 2026-08-11
 
 ### 🐛 Fixed
@@ -3092,7 +3100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.28...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.29...HEAD
+[1.6.29]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.29
 [1.6.28]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.28
 [1.6.27]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.27
 [1.6.26]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.26

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,14 @@
 
 
 
+## [1.6.29] - 2026-08-11
+
+### 🐛 修复
+
+- **workflow**: 标准化空脚本源 (@TomyJan)
+- **workflow**: 处理没有源的遗留脚本节点 (@TomyJan)
+- **workflow-approval**: 保护陈旧的摘要关联 (@TomyJan)
+
 ## [1.6.28] - 2026-08-11
 
 ### 🐛 修复
@@ -3092,7 +3100,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.28...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.29...HEAD
+[1.6.29]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.29
 [1.6.28]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.28
 [1.6.27]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.27
 [1.6.26]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.26


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增 1.6.29 版本更新日志。
  * 记录 workflow 和 workflow-approval 相关的三项问题修复。
  * 更新中英文版本对比及发布链接。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->