### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.30] - 2026-08-12
+
+### 🐛 Fixed
+
+- **workflow-approval**: handle approval serialization contexts (@TomyJan)
+
 ## [1.6.29] - 2026-08-11
 
 ### 🐛 Fixed
@@ -3100,7 +3106,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.29...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.30...HEAD
+[1.6.30]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.30
 [1.6.29]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.29
 [1.6.28]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.28
 [1.6.27]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.27

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,12 @@
 
 
 
+## [1.6.30] - 2026-08-12
+
+### 🐛 修复
+
+- **workflow-approval**: 处理批准序列化上下文 (@TomyJan)
+
 ## [1.6.29] - 2026-08-11
 
 ### 🐛 修复
@@ -3100,7 +3106,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.29...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.30...HEAD
+[1.6.30]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.30
 [1.6.29]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.29
 [1.6.28]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.28
 [1.6.27]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.27


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 `workflow-approval` 在审批序列化过程中上下文处理不正确的问题。
* **Documentation**
  * 新增 1.6.30 版本变更记录（2026-08-12）。
  * 更新中英文版本比较链接，使“未发布”内容基于 1.6.30。
  * 补充 1.6.30 发布链接，便于查看完整版本信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->