### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.31] - 2026-08-12
+
+### 🐛 Fixed
+
+- **workflow**: preserve date schedules across save delays (@TomyJan)
+
 ## [1.6.30] - 2026-08-12
 
 ### 🐛 Fixed
@@ -3106,7 +3112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.30...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.31...HEAD
+[1.6.31]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.31
 [1.6.30]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.30
 [1.6.29]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.29
 [1.6.28]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.28

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,12 @@
 
 
 
+## [1.6.31] - 2026-08-12
+
+### 🐛 修复
+
+- **workflow**: 在保存延迟期间保留日期安排 (@TomyJan)
+
 ## [1.6.30] - 2026-08-12
 
 ### 🐛 修复
@@ -3106,7 +3112,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.30...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.31...HEAD
+[1.6.31]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.31
 [1.6.30]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.30
 [1.6.29]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.29
 [1.6.28]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.28


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 workflow 在保存延迟期间无法保留日期计划的问题。

* **Documentation**
  * 新增 1.6.31 版本记录及发布日期信息。
  * 更新中英文变更日志的版本比较与发布链接。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->