### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.32] - 2026-08-12
+
+### 🐛 Fixed
+
+- **tenant**: query collection metadata JSON fields (@TomyJan)
+
 ## [1.6.31] - 2026-08-12
 
 ### 🐛 Fixed
@@ -3112,7 +3118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.31...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.32...HEAD
+[1.6.32]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.32
 [1.6.31]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.31
 [1.6.30]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.30
 [1.6.29]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.29

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,12 @@
 
 
 
+## [1.6.32] - 2026-08-12
+
+### 🐛 修复
+
+- **tenant**: 查询集合元数据 JSON 字段 (@TomyJan)
+
 ## [1.6.31] - 2026-08-12
 
 ### 🐛 修复
@@ -3112,7 +3118,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.31...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.32...HEAD
+[1.6.32]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.32
 [1.6.31]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.31
 [1.6.30]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.30
 [1.6.29]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.29


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.