### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.33] - 2026-08-13
+
+### 🐛 Fixed
+
+- **event-source**: preserve trusted workflow execution (@TomyJan)
+- **collection**: load missing db2cm associations (@TomyJan)
+- **tenant**: preserve dynamic associations when disabling tenancy (@TomyJan)
+- **tenant**: wait for tenant context before mounting app (@TomyJan)
+- **hera**: restore legacy print style association (@TomyJan)
+
 ## [1.6.32] - 2026-08-12
 
 ### 🐛 Fixed
@@ -3118,7 +3128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.32...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.33...HEAD
+[1.6.33]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.33
 [1.6.32]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.32
 [1.6.31]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.31
 [1.6.30]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.30

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,16 @@
 
 
 
+## [1.6.33] - 2026-08-13
+
+### 🐛 修复
+
+- **event-source**: 保留可信的工作流程执行 (@TomyJan)
+- **collection**: 加载缺少的 db2cm 关联 (@TomyJan)
+- **tenant**: 禁用租赁时保留动态关联 (@TomyJan)
+- **tenant**: 安装应用程序之前等待租户上下文 (@TomyJan)
+- **hera**: 恢复传统印刷风格关联 (@TomyJan)
+
 ## [1.6.32] - 2026-08-12
 
 ### 🐛 修复
@@ -3118,7 +3128,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.32...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.33...HEAD
+[1.6.33]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.33
 [1.6.32]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.32
 [1.6.31]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.31
 [1.6.30]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.30


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 新增 1.6.33（2026-08-13）版本更新记录。
  - 补充 event-source、collection、tenant、hera 和工作流相关的六项修复说明。
  - 更新中英文版本比较链接及 1.6.33 发布链接。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->