### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.34] - 2026-08-13
+
+### 🐛 Fixed
+
+- **auth**: expose security utilities from source entry (@TomyJan)
+- **tenant**: allow legacy reads before tenant setup (@TomyJan)
+- **security**: prevent authentication secret exposure (@TomyJan)
+
 ## [1.6.33] - 2026-08-13
 
 ### 🐛 Fixed
@@ -3128,7 +3136,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.33...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.34...HEAD
+[1.6.34]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.34
 [1.6.33]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.33
 [1.6.32]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.32
 [1.6.31]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.31

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,14 @@
 
 
 
+## [1.6.34] - 2026-08-13
+
+### 🐛 修复
+
+- **auth**: 从源条目公开安全实用程序 (@TomyJan)
+- **tenant**: 在租户设置之前允许旧读取 (@TomyJan)
+- **security**: 防止身份验证秘密泄露 (@TomyJan)
+
 ## [1.6.33] - 2026-08-13
 
 ### 🐛 修复
@@ -3128,7 +3136,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.33...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.34...HEAD
+[1.6.34]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.34
 [1.6.33]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.33
 [1.6.32]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.32
 [1.6.31]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.31


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增 1.6.34 版本发布记录。
  * 记录认证、租户和安全相关的三项修复。
  * 更新未发布版本的比较链接及 1.6.34 发布链接。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->