### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Added
+
+- add without context  pop-up window ([#402](https://github.com/tegojs/tego-standard/pull/402)) [0833954](https://github.com/tegojs/tego-standard/commit/083395403961d44734ef655b3a7fa3bd8fe19a2a) (@dududuna)
+
 
 
 ## [1.6.34] - 2026-08-13

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -7,6 +7,10 @@
 
 ## [未发布]
 
+### ✨ 新增
+
+- 添加无上下文弹出窗口 ([#402](https://github.com/tegojs/tego-standard/pull/402)) [0833954](https://github.com/tegojs/tego-standard/commit/083395403961d44734ef655b3a7fa3bd8fe19a2a) (@dududuna)
+
 
 
 ## [1.6.34] - 2026-08-13


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增无上下文弹出窗口功能。

- **文档**
  - 在中英文更新日志的“未发布”版本中记录该功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->