### PR TITLE
docs(changelog): sync full changelog from tego-standard

### DIFF
--- a/docs/en/changelog/changelog.md
+++ b/docs/en/changelog/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [1.6.37] - 2026-08-20
+
+### 🐛 Fixed
+
+- **tenant**: allow readable legacy links in root creates ([#408](https://github.com/tegojs/tego-standard/pull/408)) (@TomyJan)
+
 ## [1.6.36] - 2026-08-20
 
 ### 🐛 Fixed
@@ -3153,7 +3159,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.36...HEAD
+[Unreleased]: https://github.com/tegojs/tego-standard/compare/v1.6.37...HEAD
+[1.6.37]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.37
 [1.6.36]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.36
 [1.6.35]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.35
 [1.6.34]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.34

--- a/docs/zh/changelog/changelog.md
+++ b/docs/zh/changelog/changelog.md
@@ -9,6 +9,12 @@
 
 
 
+## [1.6.37] - 2026-08-20
+
+### 🐛 修复
+
+- **tenant**: 允许在根目录中创建可读的旧链接 ([#408](https://github.com/tegojs/tego-standard/pull/408)) (@TomyJan)
+
 ## [1.6.36] - 2026-08-20
 
 ### 🐛 修复
@@ -3153,7 +3159,8 @@
 - 更新自述文件 ([#1595](https://github.com/tegojs/tego-standard/pull/1595)) (@sealday)
 
 
-[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.36...HEAD
+[未发布]: https://github.com/tegojs/tego-standard/compare/v1.6.37...HEAD
+[1.6.37]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.37
 [1.6.36]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.36
 [1.6.35]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.35
 [1.6.34]: https://github.com/tegojs/tego-standard/releases/tag/v1.6.34


### PR DESCRIPTION
Automatically sync full changelog files from tego-standard repository to ensure consistency. This PR overwrites the changelog files in docs repository with the complete changelog from tego-standard repository.